### PR TITLE
wave: document per-org points budget

### DIFF
--- a/docs/pages/wave/maintainers/points-budgets.mdx
+++ b/docs/pages/wave/maintainers/points-budgets.mdx
@@ -1,14 +1,16 @@
 # Points Budgets
 
-Wave Programs may have a **per-repo points budget** configured, which caps the total points that any single repository can contribute per Wave cycle. This helps ensure that no one repo dominates the reward pool, encouraging a more balanced distribution of issues across all participating repositories.
+Wave Programs may have two points budgets configured: a **per-repo budget** that caps the points any single repository can contribute per Wave, and a **per-org budget** that caps the combined points across all of an org's approved repos per Wave. These caps help ensure that no one repo or org dominates the reward pool, encouraging a more balanced distribution of issues across all participating repositories.
 
 ## How It Works
 
-When a points budget is configured on a Wave Program, each approved repository is individually capped at that budget's worth of **points** (base points plus complexity bonuses, before any featured multiplier) per Wave. For example, with a budget of 500 points, a single repo could have up to five Trivial issues (100 points each) or a mix of complexities totaling 500 points resolved in each individual Wave.
+When points budgets are configured on a Wave Program, an issue counts toward the budget at its **pre-multiplier points** — that's the issue's base points plus its complexity bonus, before any featured-repo multiplier is applied. Every active issue from a given repo counts against that repo's per-repo budget, and every active issue from any of an org's approved repos also counts against that org's per-org budget.
 
-The budget is enforced whenever an issue is added to the Program — whether through the dashboard or the GitHub label workflow. If adding an issue would cause a repo to exceed its budget, the action is blocked.
+For example, with a per-repo budget of 500 points and a per-org budget of 2,000 points, a single repo could resolve up to five Trivial issues (100 points each) per Wave, and any one of the org's approved repos could draw from the shared 2,000-point org pool — but the combined points across all of the org's repos cannot exceed 2,000.
 
-Points budgets reset at the end of each Wave. Resolved issues from past Waves no longer count against the budget, while unresolved issues carry over until they are completed or removed.
+Both caps are enforced whenever an issue is added to the Program — whether through the dashboard or the GitHub label workflow. If adding an issue would cause either the repo or the org to exceed its budget, the action is blocked.
+
+Points budgets reset at the end of each Wave. Resolved issues from past Waves no longer count against either budget, while unresolved issues carry over until they are completed or removed.
 
 ## How to stay within your budget
 
@@ -18,20 +20,22 @@ Points budgets reset at the end of each Wave. Resolved issues from past Waves no
 
 ## Viewing Your Budget
 
-You can see each repo's current budget status on the **Maintainers → Orgs & Repos** page. For each approved repo, you will see:
+You can see your current budget status on the **Maintainers → Orgs & Repos** page:
 
-- **Points used**: The total base points currently counting against the budget.
-- **Points budget**: The per-repo limit set by the Wave Program.
+- The **Orgs** section shows one card per org you're a member of (with at least one approved repo), with a Wave Program selector and the org's points used / per-org budget for that Wave.
+- The **Repo Applications** section shows each approved repo with its points used / per-repo budget.
+
+In both places the "points used" value is the total pre-multiplier points (base + complexity bonus) currently counting against the budget for the active Wave.
 
 ### Budget Enforcement
 
-The budget is checked in three places:
+Both budgets are checked in three places:
 
-- **Dashboard**: Adding an issue or increasing an issue's complexity returns an error if the repo's budget would be exceeded.
-- **GitHub label**: If someone applies the Wave label to an issue that would push the repo over budget, the label is automatically removed and the Drips Wave bot posts a comment explaining why.
-- **Re-opening issues**: If you close an issue that has not been resolved (i.e. no points awarded, for example if "closed as not planned"), it will remain in the Wave Program, but no longer count against the budget. If you later re-open that issue, it will again count against the budget. If re-opening the issue would cause the repo to exceed its current remaining points budget, it will automatically be removed from the Wave Program.
+- **Dashboard**: Adding an issue or increasing an issue's complexity returns an error if either the repo's or the org's budget would be exceeded.
+- **GitHub label**: If someone applies the Wave label to an issue that would push the repo or the org over budget, the label is automatically removed and the Drips Wave bot posts a comment explaining which budget was exceeded.
+- **Re-opening issues**: If you close an issue that has not been resolved (i.e. no points awarded, for example if "closed as not planned"), it will remain in the Wave Program, but no longer count against either budget. If you later re-open that issue, it will again count against both budgets. If re-opening the issue would cause the repo or the org to exceed its current remaining points budget, it will automatically be removed from the Wave Program.
 
-Decreasing an issue's complexity, or removing an issue from a Wave Program is of course **always allowed**, even if the repo is currently over budget.
+Decreasing an issue's complexity, or removing an issue from a Wave Program is of course **always allowed**, even if the repo or org is currently over budget.
 
 :::info
 If your repo has been **featured** by the Wave Program organizers with a points multiplier, the budget is counted **before** the multiplier is applied. This means featured repos can add the same number of issues as non-featured ones — for example, a repo with a 2x multiplier and a 500-point budget can still add five Trivial issues, not just two.
@@ -39,10 +43,10 @@ If your repo has been **featured** by the Wave Program organizers with a points 
 
 ### Budget Resets Per Wave
 
-The budget resets at the end of each Wave cycle:
+Both budgets reset at the end of each Wave cycle:
 
-- **Resolved issues** from past Waves fall off the budget entirely — they no longer count toward the limit.
-- **Unresolved issues** carry over and continue to count against the budget until they are completed or removed.
+- **Resolved issues** from past Waves fall off the budgets entirely — they no longer count toward either limit.
+- **Unresolved issues** carry over and continue to count against both budgets until they are completed or removed.
 
 This means that at the start of a new Wave cycle, your available budget depends only on any unresolved issues still active in the Program.
 
@@ -50,4 +54,4 @@ This means that at the start of a new Wave cycle, your available budget depends 
 
 ### I need more points in my budget
 
-If you have a strong case for needing more points in your budget for a specific repo, particularly if it's a monorepo, please open a support ticket on the [Drips Discord](https://discord.gg/BakDKKDpHF) and provide details about your situation.
+If you have a strong case for needing more points in your per-repo or per-org budget — particularly if it's a monorepo, or an org with many active repos — please open a support ticket on the [Drips Discord](https://discord.gg/BakDKKDpHF) and provide details about your situation.


### PR DESCRIPTION
## Summary

Updates `wave/maintainers/points-budgets` to cover the new **per-org** points cap that's added alongside the existing per-repo cap (drips-network/wave#590, drips-network/app#1904).

- Intro and "How It Works" now describe both caps: the per-repo budget per approved repo, and the per-org budget shared across all of an org's approved repos in a Wave Program.
- Replaces the "base points" shorthand with "pre-multiplier points (base + complexity bonus)" — that's the value actually summed for budget enforcement.
- "Viewing Your Budget" now points at both the new **Orgs** section (per-org gauges, with a Wave Program selector) and the existing **Repo Applications** list (per-repo gauges).
- Enforcement and reset sections updated to mention both caps.

## Test plan

- [x] Render the page locally and confirm formatting / links are intact.
- [x] Sanity-check the worked example: per-repo 500, per-org 2,000 — single Trivial = 100 pre-multiplier points.