### PR TITLE
wave: document KYC requirement for issue applications

### DIFF
--- a/docs/pages/wave/contributors/faq.mdx
+++ b/docs/pages/wave/contributors/faq.mdx
@@ -54,6 +54,12 @@ The Leaderboard (found under **Wave Program → Leaderboard**) is a real-time ra
 
 When you apply to an issue, maintainers see a summary of your public GitHub activity including metrics like Total Merged PRs, PR Merge Rate, and an OSS Activity Score. These help maintainers evaluate applicants quickly. For a full explanation of how each metric is calculated and what the categorical bins mean, see [Applicant metrics](/wave/applicant-metrics).
 
+## Why do I need to verify my identity to apply for issues?
+
+Identity verification (KYC) is a regulatory prerequisite for distributing any rewards. We ask for it upfront — before you apply — rather than at payout time, so that once you've completed an issue and earned points there are no delays when it's time to withdraw. Doing it early also helps keep reward distribution fair across the program by preventing duplicate accounts.
+
+The flow is handled by our verification partner [Sumsub](https://sumsub.com/) and usually takes under five minutes. See [Verifying your identity](/wave/contributors/solving-issues-and-earning-rewards#verifying-your-identity) for step-by-step instructions.
+
 ## Why do I need to verify my phone number?
 
 Depending on certain behind-the-scenes factors, both maintainers and contributors may occasionally be asked to verify a phone number before being able to participate in a Wave. This is a security measure designed to prevent fraudulent activity and ensure the integrity of the program. If you are prompted to verify your phone number, please follow the instructions provided in the app to complete the verification process. This typically involves receiving a code via SMS and entering it into the app to confirm your identity. 

--- a/docs/pages/wave/contributors/faq.mdx
+++ b/docs/pages/wave/contributors/faq.mdx
@@ -14,7 +14,7 @@ Once you find an issue in the Drips App, click **Apply**. You will see a text fi
 * **Tip:** Be concise. Mention your relevant experience or link to a previous PR to increase your chances of being assigned.
 
 ## Do I need to pay to participate?
-No. Participation is free. However, to receive rewards, you must complete **KYC (Know Your Customer)** verification and request withdrawal of any earned rewards to a valid wallet address. See [Withdrawing Your Rewards](/wave/withdrawing-rewards) for full instructions.
+No. Participation is free. However, you must complete **KYC (Know Your Customer)** verification before you can apply for any issue, and you'll need a valid wallet address to withdraw any rewards you earn. See [Verifying your identity](/wave/contributors/solving-issues-and-earning-rewards#verifying-your-identity) and [Withdrawing Your Rewards](/wave/withdrawing-rewards) for full instructions.
 
 ## How are my earnings calculated?
 Your earnings are not a fixed dollar amount per issue. Instead, they are based on your share of the total points earned by the community.

--- a/docs/pages/wave/contributors/solving-issues-and-earning-rewards.mdx
+++ b/docs/pages/wave/contributors/solving-issues-and-earning-rewards.mdx
@@ -42,7 +42,7 @@ Most contributors finish in under five minutes, and verification is typically ap
 
 If verification fails and is marked as retryable, you can restart the flow from **Settings → Profile**. If it's permanently rejected, reach out at [support@drips.network](mailto:support@drips.network) and we'll help you sort it out.
 
-Identity documents are handled by our verification partner under their own privacy policy. Drips only stores the verification result, not the documents themselves.
+Identity documents are handled by our verification partner under their own privacy policy. Drips only stores the verification result, not the documents themselves. Learn more in our [privacy policy](https://www.drips.network/legal/privacy).
 
 ## Finding Work
 

--- a/docs/pages/wave/contributors/solving-issues-and-earning-rewards.mdx
+++ b/docs/pages/wave/contributors/solving-issues-and-earning-rewards.mdx
@@ -12,19 +12,37 @@ By participating in a Wave, you can:
 
 ## Getting Started
 
-We recommend verifying your identity early to ensure you can withdraw rewards without delays after the Wave ends.
+Before you can apply for any issue, you'll need to verify your identity — this is required so that you can withdraw any rewards you earn later without delays.
 
 1.  **Sign In**: Go to [the Drips Wave app](https://www.drips.network/wave) and log in with your GitHub account.
-2.  **Complete KYC**: Navigate to Settings > Identity and Payments and follow the instructions to verify your identity. Make sure to keep an eye on your emails for updates during the verification process.
+2.  **Verify your identity**: Navigate to **Settings → Identity and Payments** and follow the instructions to complete identity verification (KYC). See [Verifying your identity](#verifying-your-identity) below for details.
 3.  **Withdrawing rewards**: Once contributions have been tallied after a Wave ends, you'll be able to withdraw any earned rewards to a wallet. See [Withdrawing Your Rewards](/wave/withdrawing-rewards) for detailed instructions on how to set up your wallet and request payouts.
 
 :::danger
-**KYC is Mandatory**: You can apply for and solve issues without KYC, but **you cannot receive rewards** until your verification is complete. We recommend doing this immediately to avoid delays at the end of a Wave.
+**KYC is Mandatory**: You must complete identity verification (KYC) before you can apply for any issue, so we can be sure you'll be able to withdraw any rewards you earn. See [Verifying your identity](#verifying-your-identity) below.
 :::
 
 :::warning
 **Important disclaimer**: Drips and Wave Program Organizers reserve the right to adjust the reward formula, manually adjust points, deduct points or withhold rewards for misbehavior, and/or distribute portions of the reward pool outside the standard Points-based formula (e.g., to incentivize maintainers contributing to the program). Depending on the Wave Program, additional rules may apply, such as a maximum cap on rewards per contributor. Please read the [Terms and Rules page](/wave/terms-and-rules) for additional details.
 :::
+
+## Verifying your identity
+
+Before you can apply to any issue in a Wave, you'll need to complete a quick identity verification (KYC). We ask for it upfront so that, once you've earned rewards by completing an issue, there are no delays when it's time to withdraw — KYC is a regulatory prerequisite for receiving any funds.
+
+### How to verify
+
+1. Sign in to [the Drips Wave app](https://www.drips.network/wave).
+2. Open **Settings → Identity and Payments**, or follow the **Verify identity** prompt that appears after you log in or try to apply to an issue.
+3. Complete the verification flow with our partner [Sumsub](https://sumsub.com/). You'll need a photo of a government-issued ID and a short selfie.
+
+Most contributors finish in under five minutes, and verification is typically approved automatically within minutes. We'll notify you by email when your status changes.
+
+### If verification doesn't go through
+
+If verification fails and is marked as retryable, you can restart the flow from **Settings → Identity and Payments**. If it's permanently rejected, reach out at [support@drips.network](mailto:support@drips.network) and we'll help you sort it out.
+
+Identity documents are handled by our verification partner under their own privacy policy. Drips only stores the verification result, not the documents themselves.
 
 ## Finding Work
 

--- a/docs/pages/wave/contributors/solving-issues-and-earning-rewards.mdx
+++ b/docs/pages/wave/contributors/solving-issues-and-earning-rewards.mdx
@@ -34,7 +34,7 @@ Before you can apply to any issue in a Wave, you'll need to complete a quick ide
 
 1. Sign in to [the Drips Wave app](https://www.drips.network/wave).
 2. Open **Settings → Profile**, or follow the **Verify identity** prompt that appears after you log in or try to apply to an issue.
-3. Complete the verification flow with our partner [Sumsub](https://sumsub.com/). You'll need a photo of a government-issued ID and a short selfie.
+3. Complete the verification flow with our partner [Sumsub](https://sumsub.com/). You'll need a photo of a government-issued ID, a short selfie, and a proof of address — a recent bank statement or utility bill that shows your full name and address works well.
 
 Most contributors finish in under five minutes, and verification is typically approved automatically within minutes. We'll notify you by email when your status changes.
 

--- a/docs/pages/wave/contributors/solving-issues-and-earning-rewards.mdx
+++ b/docs/pages/wave/contributors/solving-issues-and-earning-rewards.mdx
@@ -15,7 +15,7 @@ By participating in a Wave, you can:
 Before you can apply for any issue, you'll need to verify your identity — this is required so that you can withdraw any rewards you earn later without delays.
 
 1.  **Sign In**: Go to [the Drips Wave app](https://www.drips.network/wave) and log in with your GitHub account.
-2.  **Verify your identity**: Navigate to **Settings → Identity and Payments** and follow the instructions to complete identity verification (KYC). See [Verifying your identity](#verifying-your-identity) below for details.
+2.  **Verify your identity**: Navigate to **Settings → Profile** and follow the instructions to complete identity verification (KYC). See [Verifying your identity](#verifying-your-identity) below for details.
 3.  **Withdrawing rewards**: Once contributions have been tallied after a Wave ends, you'll be able to withdraw any earned rewards to a wallet. See [Withdrawing Your Rewards](/wave/withdrawing-rewards) for detailed instructions on how to set up your wallet and request payouts.
 
 :::danger
@@ -33,14 +33,14 @@ Before you can apply to any issue in a Wave, you'll need to complete a quick ide
 ### How to verify
 
 1. Sign in to [the Drips Wave app](https://www.drips.network/wave).
-2. Open **Settings → Identity and Payments**, or follow the **Verify identity** prompt that appears after you log in or try to apply to an issue.
+2. Open **Settings → Profile**, or follow the **Verify identity** prompt that appears after you log in or try to apply to an issue.
 3. Complete the verification flow with our partner [Sumsub](https://sumsub.com/). You'll need a photo of a government-issued ID and a short selfie.
 
 Most contributors finish in under five minutes, and verification is typically approved automatically within minutes. We'll notify you by email when your status changes.
 
 ### If verification doesn't go through
 
-If verification fails and is marked as retryable, you can restart the flow from **Settings → Identity and Payments**. If it's permanently rejected, reach out at [support@drips.network](mailto:support@drips.network) and we'll help you sort it out.
+If verification fails and is marked as retryable, you can restart the flow from **Settings → Profile**. If it's permanently rejected, reach out at [support@drips.network](mailto:support@drips.network) and we'll help you sort it out.
 
 Identity documents are handled by our verification partner under their own privacy policy. Drips only stores the verification result, not the documents themselves.
 

--- a/docs/pages/wave/points-and-rewards.mdx
+++ b/docs/pages/wave/points-and-rewards.mdx
@@ -43,10 +43,10 @@ Once a Wave concludes and the seven-day Compliment window closes, the distributi
 2.  **Withdrawals**: Your Drips Wave account will reflect any earned rewards, which you can withdraw to a wallet. You'll receive an email notification when your rewards are available. See [Withdrawing Your Rewards](/wave/withdrawing-rewards) for detailed instructions.
 
 ### Requirements to Receive Funds
-To ensure you receive your reward, you must **complete KYC**. Withdrawing rewards will only be possible with verified accounts.
+To withdraw your rewards, you must have a verified identity (**KYC**). Since identity verification is required to apply for any issue in the first place, this will already be in place by the time you earn points.
 
 :::danger
-**No KYC, No Reward**: You can earn points without KYC, but funds cannot be distributed to unverified accounts. To avoid forfeiting your reward, please complete this process early.
+**KYC is Mandatory**: Identity verification is required to apply for issues and to withdraw any rewards you earn. See [Verifying your identity](/wave/contributors/solving-issues-and-earning-rewards#verifying-your-identity) for details.
 :::
 
 ## Frequently Asked Questions

--- a/docs/pages/wave/withdrawing-rewards.mdx
+++ b/docs/pages/wave/withdrawing-rewards.mdx
@@ -10,7 +10,7 @@ This guide walks you through the process of withdrawing your rewards to your Ste
 
 Before you can withdraw rewards, you must:
 
-1. **Complete KYC Verification**: Navigate to **Settings → Identity and Payments** and complete the identity verification process. You cannot withdraw any funds until your KYC status is approved.
+1. **Complete KYC Verification**: Navigate to **Settings → Profile** and complete the identity verification process. You cannot withdraw any funds until your KYC status is approved.
 2. **Have a Stellar Wallet**: You'll need a Stellar wallet that supports USDC. Popular options include [LOBSTR](https://lobstr.co/) (mobile app), [Ledger](https://www.ledger.com/) (via Ledger Live or compatible wallet), or any other wallet compatible with the Stellar network. You can also withdraw to a centralized exchange, provided it supports **USDC deposits specifically on the Stellar network**.
 3. **Activate the wallet and enable the USDC Trustline**:
     * **Activation:** Your wallet must hold a small minimum balance of **XLM** (Stellar Lumens) to be active.


### PR DESCRIPTION
## Summary

Companion docs for [drips-network/wave#596](https://github.com/drips-network/wave/pull/596) (gates issue applications behind verified KYC) and [drips-network/app#1906](https://github.com/drips-network/app/pull/1906) (frontend prompt + blocker).

The app links to `solving-issues-and-earning-rewards#verifying-your-identity` from the in-app KYC prompt, so this PR introduces that anchor and aligns surrounding copy with the new rule that KYC is required to *apply*, not just to *withdraw*.

## Changes

- `wave/contributors/solving-issues-and-earning-rewards.mdx`
  - **New section `## Verifying your identity`** — the destination the app's "Learn more" link points to. Covers why, how (Sumsub flow, ID + selfie, &lt;5 min), and what to do on failure.
  - Updated `## Getting Started` intro and step 2 to lead with the new gate.
  - Updated the `:::danger` callout from "you can apply without KYC" to "you can't apply without KYC."
- `wave/points-and-rewards.mdx`
  - Reworded the "Requirements to Receive Funds" paragraph and the `:::danger` callout to reflect that KYC happens at application time.
- `wave/contributors/faq.mdx`
  - "Do I need to pay to participate?" answer now mentions the KYC-at-application gate alongside the withdrawal wallet requirement.

## Untouched

- `wave/withdrawing-rewards.mdx` — still accurate (withdrawal-time KYC requirement is unchanged).
- `wave/terms-and-rules.mdx` — legal language about KYC as a prerequisite for reward allocation still holds.

## Test plan

- [x] Build the site locally and confirm `#verifying-your-identity` is reachable from `solving-issues-and-earning-rewards`.
- [x] Confirm the cross-page links from `points-and-rewards` and `faq` resolve.